### PR TITLE
test-5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: bash
-
 script:
-    - echo "foo bar"
+- echo "foo bar"
+- false
 
+notifications:
+  slack:
+    secure: hmUWjNZTVkSMnoB/n6Jo451LvwJU8/Q6Ly0ComZFbRSB7z9UE/9I28k16suSXqSqGLpdaYzVM8rc5mKN0ChuZ7m4g61cvWNY4j4PwhhDWZkVu0zusRWUOKEpmF8r/WeM9GY1Ins2UxJLsjnkF3vs2mutGRdnrtVFjYFVixa0GB3bwFvOcyf+z/8fJhELWgRZVJQtc8FULwm+AwBiWc5mwTS0s4wdPJofNP8t7TGDFSJB0opAnEfcLgS7l1vy4VQVFzSGJPbajbg6wQHkVlyXidEKg/04GAUyg3k1NFTDbwh2F2KB6av4kkGsl7htU0AuKKQJTTyIpwVlNM9xma+GwI7fw7RqATkd5vXvH9aQm+c+3QYMeJwl+/QMExXyym6QaELQOfNkyVB6IwAe8Mhg4ao0kHHsL1j1dJeBOWc18xMjUqm9U7Ee25TfkzX9EkVGwnR+Bmd0bA2GOuIrgGB3XJyWsMTzOWpYdf/Ch4E63OGr5XOmKNzd10Gu92xWehXYA5Y8JGvP7NOCbB21NEPHYhrRtNah9vZg2vN2g1rXuyceyW4Dpu/GvqAbjg0OGxLm+v3VzRBVhe8BU9mLeVcDhWHbHSSYHvck7SGvdVVgaWRp+MjMwiJ2bKXwxuhcFFxVzXNkgQsL+p4O7Q97qddehEG4nJP2+T/UGY0aOLbQLx4=
+    on_success: change
+    on_failure: always
+    on_pull_requests: false


### PR DESCRIPTION
Aiming for channel specific, failure only notifications.

Invoked 
`travis encrypt "scalescale:<scale-scale-test-key>#ci-test-2" --add-notifications.slack -r michaeldaywrites/travis`